### PR TITLE
[jsscripting] Upgrade openhab-js to 4.5.0

### DIFF
--- a/bundles/org.openhab.automation.jsscripting/pom.xml
+++ b/bundles/org.openhab.automation.jsscripting/pom.xml
@@ -24,7 +24,7 @@
     </bnd.importpackage>
     <graal.version>22.0.0.2</graal.version> <!-- DO NOT UPGRADE: 22.0.0.2 is the latest version working on armv7l / OpenJDK 11.0.16 & armv7l / Zulu 17.0.5+8 -->
     <oh.version>${project.version}</oh.version>
-    <ohjs.version>openhab@4.4.0</ohjs.version>
+    <ohjs.version>openhab@4.5.0</ohjs.version>
   </properties>
 
   <build>


### PR DESCRIPTION
For changelog, see https://github.com/openhab/openhab-js/blob/v4.5.0/CHANGELOG.md#450.