### PR TITLE
[yamahamusiccast] Add discovery information

### DIFF
--- a/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
+++ b/bundles/org.openhab.binding.yamahamusiccast/src/main/resources/OH-INF/addon/addon.xml
@@ -8,4 +8,20 @@
 	<description>This is the binding for Yamaha Musiccast</description>
 	<connection>local</connection>
 
+	<discovery-methods>
+		<discovery-method>
+			<service-type>upnp</service-type>
+			<match-properties>
+				<match-property>
+					<name>manufacturer</name>
+					<regex>(?i).*Yamaha.*</regex>
+				</match-property>
+				<match-property>
+					<name>deviceType</name>
+					<regex>.*MediaRenderer.*</regex>
+				</match-property>
+			</match-properties>
+		</discovery-method>
+	</discovery-methods>
+
 </addon:addon>


### PR DESCRIPTION
Seems like Yamaha is using uppercase `YAMAHA CORPORATION` for the manufacturer info of non-MusicCast devices and normal case `Yamaha Corporation` for MusicCast devices.

Signed-off-by: Florian Hotze <florianh_dev@icloud.com>